### PR TITLE
Update dependendecies to support newer ScalaJS and Java 11+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,8 @@ import scala.language.postfixOps
 
 val scalaJsIOVersion = "0.4.2"
 val apiVersion = scalaJsIOVersion
-val scalaJsVersion = "2.12.3"
+val scalaJsVersion = "2.12.8"
+val scalatestVersion = "3.0.5"
 
 homepage := Some(url("https://github.com/scalajs-io/core"))
 
@@ -19,13 +20,13 @@ lazy val root = (project in file(".")).
     description := "Core utilities for the ScalaJs.io platform",
     version := apiVersion,
     scalaVersion := scalaJsVersion,
-    scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:implicitConversions", "-Xlint"),
+    scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:implicitConversions", "-Xlint", "-P:scalajs:sjsDefinedByDefault"),
     scalacOptions in(Compile, doc) ++= Seq("-no-link-warnings"),
     autoCompilerPlugins := true,
     scalaJSModuleKind := ModuleKind.CommonJSModule,
     libraryDependencies ++= Seq(
 	    "org.scala-lang" % "scala-reflect" % scalaJsVersion,
-	    "org.scalatest" %%% "scalatest" % "3.0.1" % "test"
+	    "org.scalatest" %%% "scalatest" % scalatestVersion % "test"
   ))
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,12 @@
 // Scala.js
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.20")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
 
 // Publishing
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 // Resolvers
 


### PR DESCRIPTION
This PR updates dependencies so scalajs-io works on Java 11+ and newer ScalaJS.
